### PR TITLE
Patch for downloading hidden galleries (cookies)

### DIFF
--- a/pinterest-downloader.py
+++ b/pinterest-downloader.py
@@ -1632,7 +1632,7 @@ def run_library_main(arg_path :str, arg_dir :str, arg_thread_max :int, arg_cut :
             PIN_SESSION = get_session(0, proxies, cookies)
             IMG_SESSION = get_session(3, proxies, cookies)
             V_SESSION = get_session(4, proxies, cookies)
-            get_pin_info(pin_id.strip(), arg_log_timestamp, url_path, arg_force, arg_img_only, arg_v_only, arg_dir, arg_cut, arg_el, fs_f_max, IMG_SESSION, V_SESSION, PIN_SESSION, proxies, cookie_file, False)
+            get_pin_info(pin_id.strip(), arg_log_timestamp, url_path, arg_force, arg_img_only, arg_v_only, arg_dir, arg_cut, arg_el, fs_f_max, IMG_SESSION, V_SESSION, PIN_SESSION, proxies, cookies, False)
 
     if len(slash_path) == 3:
         sec_path = '/'.join(slash_path)

--- a/pinterest-downloader.py
+++ b/pinterest-downloader.py
@@ -1036,7 +1036,7 @@ def write_log(arg_timestamp_log, url_path, shortform
         # Don't want combine with old log or else you need open the file to see got title/desc or not even though no content.
         log_url_path = os.path.join(save_dir, 'urls-pinterest-downloader.urls')
 
-        with open(log_url_path, 'w') as f:
+        with open(log_url_path, 'w', encoding="utf-8") as f:
             f.write('Pinterest Downloader: Version ' + str(__version__)  + '\n\n') # Easy to recognize if future want to change something
             # Ensure -ua same parsing format
             f.write('Input URL: https://www.pinterest.com/' + url_path.rstrip('/')  + '/\n') # Reuse/refer when want to update
@@ -1050,7 +1050,7 @@ def write_log(arg_timestamp_log, url_path, shortform
 
         if break_from_latest_pin and not arg_timestamp_log:
             try:
-                with open(log_path) as f:
+                with open(log_path, encoding="utf-8") as f:
                     index_line = [l for l in f.readlines() if l.startswith('[ ')]
                     index_last_tmp = index_line[-1].split('[ ')[1].split(' ]')[0]
                     if index_last_tmp.isdigit():


### PR DESCRIPTION
Added ability of specifying a cookie file. The cookie file needs to be in the format of a token like the one generated by this extension: https://chrome.google.com/webstore/detail/get-token-cookie/naciaagbkifhpnoodlkhbejjldaiffcm

Example: given that the info from the extension is saved in a file named "cookies.txt" and placed in the same folder as "pinterest-downloader.py", now we can call "python pinterest-downloader.py https://www.pinterest.co.uk/usename --cookies cookies.txt" and also hidden galleries for your user will be downloaded